### PR TITLE
Make ignore-scripts configurable

### DIFF
--- a/tasks/package_modules.js
+++ b/tasks/package_modules.js
@@ -43,7 +43,7 @@ module.exports = function(grunt) {
 
       npm.load({
         production: true,
-        "ignore-scripts": true,
+        "ignore-scripts": f.ignoreScripts === undefined ? true : f.ignoreScripts,
         prefix: f.dest
       }, function(err) {
         if(err) {


### PR DESCRIPTION
The previous code always invoked npm install with ignore-scripts = true. This
is inconvienent in some cases when it is desired to compile C/C++ modules when
creating the package.

This change provides an ignoreScripts config option, which defaults to true
if not provided, in order to maintain the existing functionality.

An example Gruntfile:
        packageModules: {
            dist: {
                ignoreScripts: false,
                src: 'package.json',
                dest: 'dist'
            }
        },
